### PR TITLE
Add session form history API and detailed view endpoints

### DIFF
--- a/DriveFlow-CRM-API/Controllers/SessionFormController.cs
+++ b/DriveFlow-CRM-API/Controllers/SessionFormController.cs
@@ -12,8 +12,8 @@ namespace DriveFlow_CRM_API.Controllers;
 /// Controller for managing session forms during driving lessons.
 /// </summary>
 [ApiController]
-[Route("api/appointments")]
-[Authorize(Roles = "Instructor")]
+[Route("api/session-forms")]
+[Authorize(Roles = "Instructor,Student,SchoolAdmin")]
 public class SessionFormController : ControllerBase
 {
     private readonly ApplicationDbContext _db;
@@ -25,6 +25,142 @@ public class SessionFormController : ControllerBase
     {
         _db = db;
         _users = users;
+    }
+
+    /// <summary>
+    /// Retrieves a session form with all details including mistake breakdown.
+    /// </summary>
+    /// <remarks>
+    /// <para>Access control:</para>
+    /// <list type="bullet">
+    /// <item>Instructor: must own the appointment's file</item>
+    /// <item>Student: must be the student on the file</item>
+    /// <item>SchoolAdmin: must belong to the same school</item>
+    /// </list>
+    /// 
+    /// <para><strong>Sample response (200 OK):</strong></para>
+    /// ```json
+    /// {
+    ///   "id": 501,
+    ///   "appointmentDate": "2025-11-01",
+    ///   "studentName": "Ionescu Maria",
+    ///   "instructorName": "Popescu Ion",
+    ///   "totalPoints": 24,
+    ///   "maxPoints": 21,
+    ///   "result": "FAILED",
+    ///   "mistakes": [
+    ///     {
+    ///       "id_item": 1,
+    ///       "description": "Semnalizare la schimbarea direc?iei",
+    ///       "count": 3,
+    ///       "penaltyPoints": 3
+    ///     }
+    ///   ],
+    ///   "isLocked": true
+    /// }
+    /// ```
+    /// </remarks>
+    /// <param name="id">The session form ID</param>
+    /// <response code="200">Session form retrieved successfully.</response>
+    /// <response code="401">No valid JWT supplied.</response>
+    /// <response code="403">User is not authorized to view this session form.</response>
+    /// <response code="404">Session form not found.</response>
+    [HttpGet("{id}")]
+    [ProducesResponseType(typeof(SessionFormViewDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<SessionFormViewDto>> Get(int id)
+    {
+        // 1. Get authenticated user
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrEmpty(userId))
+            return Unauthorized();
+
+        var user = await _users.FindByIdAsync(userId);
+        if (user == null)
+            return Unauthorized();
+
+        // 2. Get session form with all required relationships
+        var sessionForm = await _db.SessionForms
+            .Include(sf => sf.Appointment)
+                .ThenInclude(a => a.File)
+                    .ThenInclude(f => f.Student)
+            .Include(sf => sf.Appointment)
+                .ThenInclude(a => a.File)
+                    .ThenInclude(f => f.Instructor)
+            .Include(sf => sf.ExamForm)
+                .ThenInclude(ef => ef.Items)
+            .FirstOrDefaultAsync(sf => sf.SessionFormId == id);
+
+        if (sessionForm == null)
+            return NotFound(new { message = "Session form not found." });
+
+        // 3. Authorization checks
+        var file = sessionForm.Appointment?.File;
+        if (file == null)
+            return NotFound(new { message = "Associated file not found." });
+
+        var isInstructor = User.IsInRole("Instructor");
+        var isStudent = User.IsInRole("Student");
+        var isSchoolAdmin = User.IsInRole("SchoolAdmin");
+
+        // Instructor: must own the file
+        if (isInstructor && file.InstructorId != userId)
+            return Forbid();
+
+        // Student: must be the student on the file
+        if (isStudent && file.StudentId != userId)
+            return Forbid();
+
+        // SchoolAdmin: must belong to the same school
+        if (isSchoolAdmin && user.AutoSchoolId != file.Student?.AutoSchoolId)
+            return Forbid();
+
+        // 4. Parse mistakes JSON
+        List<MistakeEntry> mistakes;
+        try
+        {
+            mistakes = System.Text.Json.JsonSerializer.Deserialize<List<MistakeEntry>>(sessionForm.MistakesJson) ?? new List<MistakeEntry>();
+        }
+        catch
+        {
+            mistakes = new List<MistakeEntry>();
+        }
+
+        // 5. Build mistake breakdown with item details
+        var mistakeBreakdown = mistakes
+            .Select(m =>
+            {
+                var item = sessionForm.ExamForm.Items.FirstOrDefault(i => i.ItemId == m.id_item);
+                return item != null
+                    ? new MistakeBreakdownDto(
+                        id_item: m.id_item,
+                        description: item.Description,
+                        count: m.count,
+                        penaltyPoints: item.PenaltyPoints
+                    )
+                    : null;
+            })
+            .Where(m => m != null)
+            .Cast<MistakeBreakdownDto>()
+            .OrderBy(m => m.id_item)
+            .ToList();
+
+        // 6. Build response DTO
+        var dto = new SessionFormViewDto(
+            id: sessionForm.SessionFormId,
+            appointmentDate: DateOnly.FromDateTime(sessionForm.Appointment.Date),
+            studentName: $"{file.Student?.FirstName} {file.Student?.LastName}",
+            instructorName: $"{file.Instructor?.FirstName} {file.Instructor?.LastName}",
+            totalPoints: sessionForm.TotalPoints,
+            maxPoints: sessionForm.ExamForm.MaxPoints,
+            result: sessionForm.Result,
+            isLocked: sessionForm.IsLocked,
+            mistakes: mistakeBreakdown
+        );
+
+        return Ok(dto);
     }
 
     /// <summary>
@@ -377,6 +513,180 @@ public class SessionFormController : ControllerBase
             maxPoints: maxPoints,
             result: result
         ));
+    }
+
+    // ?????????????????????????????? GET STUDENT SESSION FORMS (HISTORY) ??????????????????????????????
+    /// <summary>
+    /// Lists all session forms for a student with optional date filtering, sorting, and pagination.
+    /// </summary>
+    /// <remarks>
+    /// <para><strong>Access control:</strong></para>
+    /// <list type="bullet">
+    /// <item>Student: can only view their own forms (self)</item>
+    /// <item>Instructor: can view forms for students in their active files</item>
+    /// <item>SchoolAdmin: can view forms for all students in their school</item>
+    /// </list>
+    ///
+    /// <para><strong>Query parameters:</strong></para>
+    /// <list type="bullet">
+    /// <item>from: Start date filter (optional, format: YYYY-MM-DD)</item>
+    /// <item>to: End date filter (optional, format: YYYY-MM-DD)</item>
+    /// <item>page: Page number (default: 1)</item>
+    /// <item>pageSize: Items per page (default: 20, max: 100)</item>
+    /// </list>
+    ///
+    /// <para><strong>Sample response (200 OK):</strong></para>
+    /// ```json
+    /// {
+    ///   "page": 1,
+    ///   "pageSize": 20,
+    ///   "total": 2,
+    ///   "items": [
+    ///     {
+    ///       "id": 502,
+    ///       "date": "2025-10-19",
+    ///       "totalPoints": 24,
+    ///       "maxPoints": 21,
+    ///       "result": "FAILED"
+    ///     },
+    ///     {
+    ///       "id": 501,
+    ///       "date": "2025-10-12",
+    ///       "totalPoints": 18,
+    ///       "maxPoints": 21,
+    ///       "result": "OK"
+    ///     }
+    ///   ]
+    /// }
+    /// ```
+    /// </remarks>
+    /// <param name="id_student">The student user ID</param>
+    /// <param name="from">Start date filter (optional)</param>
+    /// <param name="to">End date filter (optional)</param>
+    /// <param name="page">Page number (default: 1)</param>
+    /// <param name="pageSize">Items per page (default: 20, max: 100)</param>
+    /// <response code="200">Session forms retrieved successfully.</response>
+    /// <response code="400">Invalid query parameters.</response>
+    /// <response code="401">No valid JWT supplied.</response>
+    /// <response code="403">User is not authorized to view this student's forms.</response>
+    /// <response code="404">Student not found.</response>
+    [HttpGet("/api/students/{id_student}/session-forms")]
+    [ProducesResponseType(typeof(PagedResult<SessionFormListItemDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<PagedResult<SessionFormListItemDto>>> ListStudentForms(
+        string id_student,
+        [FromQuery] string? from = null,
+        [FromQuery] string? to = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20)
+    {
+        // 1. Validate pagination parameters
+        if (page < 1)
+            return BadRequest(new { message = "Page must be at least 1." });
+
+        if (pageSize < 1 || pageSize > 100)
+            return BadRequest(new { message = "PageSize must be between 1 and 100." });
+
+        // 2. Get authenticated user
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrEmpty(userId))
+            return Unauthorized();
+
+        var currentUser = await _users.FindByIdAsync(userId);
+        if (currentUser == null)
+            return Unauthorized();
+
+        // 3. Check if student exists
+        var student = await _users.FindByIdAsync(id_student);
+        if (student == null)
+            return NotFound(new { message = "Student not found." });
+
+        // 4. Authorization checks
+        var isStudent = User.IsInRole("Student");
+        var isInstructor = User.IsInRole("Instructor");
+        var isSchoolAdmin = User.IsInRole("SchoolAdmin");
+
+        // Student can only view their own forms
+        if (isStudent && userId != id_student)
+            return Forbid();
+
+        // Instructor can only view students in their active files
+        if (isInstructor)
+        {
+            var hasActiveFile = await _db.Files
+                .AnyAsync(f => f.StudentId == id_student && f.InstructorId == userId);
+
+            if (!hasActiveFile)
+                return Forbid();
+        }
+
+        // SchoolAdmin can only view students in their school
+        if (isSchoolAdmin && currentUser.AutoSchoolId != student.AutoSchoolId)
+            return Forbid();
+
+        // 5. Parse date filters
+        DateTime? fromDate = null;
+        DateTime? toDate = null;
+
+        if (!string.IsNullOrWhiteSpace(from))
+        {
+            if (!DateTime.TryParse(from, out var parsedFrom))
+                return BadRequest(new { message = "Invalid 'from' date format. Use YYYY-MM-DD." });
+            fromDate = parsedFrom.Date;
+        }
+
+        if (!string.IsNullOrWhiteSpace(to))
+        {
+            if (!DateTime.TryParse(to, out var parsedTo))
+                return BadRequest(new { message = "Invalid 'to' date format. Use YYYY-MM-DD." });
+            toDate = parsedTo.Date.AddDays(1).AddSeconds(-1); // End of day
+        }
+
+        // 6. Build query with filters
+        var query = _db.SessionForms
+            .Include(sf => sf.Appointment)
+            .Include(sf => sf.ExamForm)
+            .Where(sf => sf.Appointment.File != null && sf.Appointment.File.StudentId == id_student);
+
+        // Apply date filters
+        if (fromDate.HasValue)
+            query = query.Where(sf => sf.Appointment.Date >= fromDate.Value);
+
+        if (toDate.HasValue)
+            query = query.Where(sf => sf.Appointment.Date <= toDate.Value);
+
+        // 7. Get total count
+        var total = await query.CountAsync();
+
+        // 8. Apply sorting (descending by date) and pagination
+        var sessionForms = await query
+            .OrderByDescending(sf => sf.Appointment.Date)
+            .ThenByDescending(sf => sf.SessionFormId)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync();
+
+        // Map to DTOs after materialization
+        var items = sessionForms.Select(sf => new SessionFormListItemDto(
+            sf.SessionFormId,
+            DateOnly.FromDateTime(sf.Appointment.Date),
+            sf.TotalPoints,
+            sf.ExamForm.MaxPoints,
+            sf.Result
+        )).ToList();
+
+        // 9. Build paged result
+        var result = new PagedResult<SessionFormListItemDto>(
+            page,
+            pageSize,
+            total,
+            items
+        );
+
+        return Ok(result);
     }
 }
 

--- a/DriveFlow-CRM-API/Models/DTOs/ExamFormDtos.cs
+++ b/DriveFlow-CRM-API/Models/DTOs/ExamFormDtos.cs
@@ -15,3 +15,20 @@ public sealed record ExamFormDto(
     int maxPoints,
     IEnumerable<ExamItemDto> items
 );
+
+/// <summary>List item DTO for session form history.</summary>
+public sealed record SessionFormListItemDto(
+    int id,                 // SessionFormId
+    DateOnly date,          // Appointment date
+    int? totalPoints,       // Total penalty points (null if not finalized)
+    int maxPoints,          // Maximum allowed points
+    string? result          // "OK" or "FAILED" (null if not finalized)
+);
+
+/// <summary>Generic paged result wrapper.</summary>
+public sealed record PagedResult<T>(
+    int page,               // Current page number (1-based)
+    int pageSize,           // Items per page
+    int total,              // Total count of items
+    IEnumerable<T> items    // Current page items
+);

--- a/DriveFlow-CRM-API/Models/DTOs/SessionFormDtos.cs
+++ b/DriveFlow-CRM-API/Models/DTOs/SessionFormDtos.cs
@@ -32,3 +32,24 @@ public sealed record FinalizeResponse(
     int maxPoints,
     string result
 );
+
+/// <summary>DTO for mistake breakdown with item details.</summary>
+public sealed record MistakeBreakdownDto(
+    int id_item,
+    string description,
+    int count,
+    int penaltyPoints
+);
+
+/// <summary>DTO for viewing a complete session form with all details.</summary>
+public sealed record SessionFormViewDto(
+    int id,
+    DateOnly appointmentDate,
+    string studentName,
+    string instructorName,
+    int? totalPoints,
+    int maxPoints,
+    string? result,
+    bool isLocked,
+    IEnumerable<MistakeBreakdownDto> mistakes
+);

--- a/DriveFlow.Tests/SessionFormHistoryTest.cs
+++ b/DriveFlow.Tests/SessionFormHistoryTest.cs
@@ -1,0 +1,443 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using DriveFlow_CRM_API.Controllers;
+using DriveFlow_CRM_API.Models;
+using DriveFlow_CRM_API.Models.DTOs;
+using File = DriveFlow_CRM_API.Models.File;
+
+namespace DriveFlow.Tests.Controllers;
+
+/// <summary>
+/// Integration tests for GET /api/students/{id_student}/session-forms endpoint.
+/// Tests student history with filtering, sorting, and pagination.
+/// </summary>
+public sealed class SessionFormHistoryTest
+{
+    private static ApplicationDbContext InMemDb() =>
+        new(new DbContextOptionsBuilder<ApplicationDbContext>()
+               .UseInMemoryDatabase($"SessionFormHistory_{Guid.NewGuid()}")
+               .Options);
+
+    private static void AttachIdentity(
+        ControllerBase controller,
+        string role,
+        string userId = "user1")
+    {
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.Role, role),
+            new Claim(ClaimTypes.NameIdentifier, userId)
+        }, authenticationType: "mock");
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(identity)
+            }
+        };
+    }
+
+    private static UserManager<ApplicationUser> GetMockedUserManager(ApplicationDbContext db)
+    {
+        var store = new UserStore<ApplicationUser>(db);
+        var options = new Microsoft.Extensions.Options.OptionsWrapper<IdentityOptions>(new IdentityOptions());
+        var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+
+        return new UserManager<ApplicationUser>(
+            store,
+            options,
+            new PasswordHasher<ApplicationUser>(),
+            new[] { new UserValidator<ApplicationUser>() },
+            new[] { new PasswordValidator<ApplicationUser>() },
+            new UpperInvariantLookupNormalizer(),
+            new IdentityErrorDescriber(),
+            null!,
+            loggerFactory.CreateLogger<UserManager<ApplicationUser>>()
+        );
+    }
+
+    private async Task<string> SetupTestData(ApplicationDbContext db, string studentId = "student1", string instructorId = "instructor1")
+    {
+        // Setup users
+        var student = new ApplicationUser { Id = studentId, UserName = $"{studentId}@test.com", AutoSchoolId = 1 };
+        var instructor = new ApplicationUser { Id = instructorId, UserName = $"{instructorId}@test.com", AutoSchoolId = 1 };
+        db.Users.AddRange(student, instructor);
+
+        // Setup category
+        var category = new TeachingCategory
+        {
+            TeachingCategoryId = 1,
+            Code = "B",
+            AutoSchoolId = 1,
+            SessionCost = 100,
+            SessionDuration = 60,
+            ScholarshipPrice = 2500,
+            MinDrivingLessonsReq = 30
+        };
+        db.TeachingCategories.Add(category);
+
+        // Setup exam form
+        var examForm = new ExamForm
+        {
+            FormId = 1,
+            TeachingCategoryId = 1,
+            MaxPoints = 21,
+            Items = new List<ExamItem>
+            {
+                new ExamItem { ItemId = 1, Description = "Semnalizare", PenaltyPoints = 3, OrderIndex = 1 }
+            }
+        };
+        db.ExamForms.Add(examForm);
+
+        // Setup file
+        var file = new File
+        {
+            FileId = 1,
+            StudentId = studentId,
+            TeachingCategoryId = 1,
+            InstructorId = instructorId,
+            Status = FileStatus.APPROVED
+        };
+        db.Files.Add(file);
+
+        await db.SaveChangesAsync();
+        return studentId;
+    }
+
+    private async Task AddSessionForm(ApplicationDbContext db, int appointmentId, DateTime date, int? totalPoints, string? result)
+    {
+        var appointment = new Appointment
+        {
+            AppointmentId = appointmentId,
+            FileId = 1,
+            Date = date,
+            StartHour = TimeSpan.FromHours(10),
+            EndHour = TimeSpan.FromHours(11)
+        };
+        db.Appointments.Add(appointment);
+
+        var sessionForm = new SessionForm
+        {
+            AppointmentId = appointmentId,
+            FormId = 1,
+            MistakesJson = "[]",
+            IsLocked = totalPoints.HasValue,
+            CreatedAt = DateTime.UtcNow,
+            TotalPoints = totalPoints,
+            Result = result,
+            FinalizedAt = totalPoints.HasValue ? DateTime.UtcNow : null
+        };
+        db.SessionForms.Add(sessionForm);
+
+        await db.SaveChangesAsync();
+    }
+
+    // ????????????? Happy Path: Student views own forms ?????????????
+    [Fact]
+    public async Task ListStudentForms_ShouldReturn200_ForOwnStudent()
+    {
+        await using var db = InMemDb();
+        var studentId = await SetupTestData(db);
+
+        // Add 3 session forms with different dates
+        await AddSessionForm(db, 1, DateTime.Today.AddDays(-10), 18, "OK");
+        await AddSessionForm(db, 2, DateTime.Today.AddDays(-5), 24, "FAILED");
+        await AddSessionForm(db, 3, DateTime.Today.AddDays(-1), null, null); // Not finalized
+
+        var userManager = GetMockedUserManager(db);
+        var controller = new SessionFormController(db, userManager);
+        AttachIdentity(controller, role: "Student", userId: studentId);
+
+        var result = await controller.ListStudentForms(studentId);
+
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.StatusCode.Should().Be(200);
+
+        var pagedResult = okResult.Value.Should().BeOfType<PagedResult<SessionFormListItemDto>>().Subject;
+        pagedResult.total.Should().Be(3);
+        pagedResult.page.Should().Be(1);
+        pagedResult.pageSize.Should().Be(20);
+
+        var items = pagedResult.items.ToList();
+        items.Should().HaveCount(3);
+
+        // Verify sorted by date descending
+        items[0].date.Should().Be(DateOnly.FromDateTime(DateTime.Today.AddDays(-1)));
+        items[1].date.Should().Be(DateOnly.FromDateTime(DateTime.Today.AddDays(-5)));
+        items[2].date.Should().Be(DateOnly.FromDateTime(DateTime.Today.AddDays(-10)));
+
+        // Verify not finalized form has null values
+        items[0].totalPoints.Should().BeNull();
+        items[0].result.Should().BeNull();
+
+        // Verify finalized forms
+        items[1].totalPoints.Should().Be(24);
+        items[1].result.Should().Be("FAILED");
+        items[2].totalPoints.Should().Be(18);
+        items[2].result.Should().Be("OK");
+    }
+
+    // ????????????? Date Filtering: from parameter ?????????????
+    [Fact]
+    public async Task ListStudentForms_ShouldFilterByFromDate()
+    {
+        await using var db = InMemDb();
+        var studentId = await SetupTestData(db);
+
+        await AddSessionForm(db, 1, DateTime.Today.AddDays(-10), 18, "OK");
+        await AddSessionForm(db, 2, DateTime.Today.AddDays(-5), 24, "FAILED");
+        await AddSessionForm(db, 3, DateTime.Today.AddDays(-1), 20, "OK");
+
+        var userManager = GetMockedUserManager(db);
+        var controller = new SessionFormController(db, userManager);
+        AttachIdentity(controller, role: "Student", userId: studentId);
+
+        var fromDate = DateTime.Today.AddDays(-6).ToString("yyyy-MM-dd");
+        var result = await controller.ListStudentForms(studentId, from: fromDate);
+
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var pagedResult = okResult.Value.Should().BeOfType<PagedResult<SessionFormListItemDto>>().Subject;
+
+        pagedResult.total.Should().Be(2); // Only forms from -5 and -1
+        pagedResult.items.ToList()[0].date.Should().Be(DateOnly.FromDateTime(DateTime.Today.AddDays(-1)));
+        pagedResult.items.ToList()[1].date.Should().Be(DateOnly.FromDateTime(DateTime.Today.AddDays(-5)));
+    }
+
+    // ????????????? Date Filtering: to parameter ?????????????
+    [Fact]
+    public async Task ListStudentForms_ShouldFilterByToDate()
+    {
+        await using var db = InMemDb();
+        var studentId = await SetupTestData(db);
+
+        await AddSessionForm(db, 1, DateTime.Today.AddDays(-10), 18, "OK");
+        await AddSessionForm(db, 2, DateTime.Today.AddDays(-5), 24, "FAILED");
+        await AddSessionForm(db, 3, DateTime.Today.AddDays(-1), 20, "OK");
+
+        var userManager = GetMockedUserManager(db);
+        var controller = new SessionFormController(db, userManager);
+        AttachIdentity(controller, role: "Student", userId: studentId);
+
+        var toDate = DateTime.Today.AddDays(-6).ToString("yyyy-MM-dd");
+        var result = await controller.ListStudentForms(studentId, to: toDate);
+
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var pagedResult = okResult.Value.Should().BeOfType<PagedResult<SessionFormListItemDto>>().Subject;
+
+        pagedResult.total.Should().Be(1); // Only form from -10
+        pagedResult.items.ToList()[0].date.Should().Be(DateOnly.FromDateTime(DateTime.Today.AddDays(-10)));
+    }
+
+    // ????????????? Pagination: page 2 ?????????????
+    [Fact]
+    public async Task ListStudentForms_ShouldPaginateCorrectly()
+    {
+        await using var db = InMemDb();
+        var studentId = await SetupTestData(db);
+
+        // Add 5 session forms
+        for (int i = 0; i < 5; i++)
+        {
+            await AddSessionForm(db, i + 1, DateTime.Today.AddDays(-i), 18, "OK");
+        }
+
+        var userManager = GetMockedUserManager(db);
+        var controller = new SessionFormController(db, userManager);
+        AttachIdentity(controller, role: "Student", userId: studentId);
+
+        // Get page 2 with pageSize=2
+        var result = await controller.ListStudentForms(studentId, page: 2, pageSize: 2);
+
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var pagedResult = okResult.Value.Should().BeOfType<PagedResult<SessionFormListItemDto>>().Subject;
+
+        pagedResult.total.Should().Be(5);
+        pagedResult.page.Should().Be(2);
+        pagedResult.pageSize.Should().Be(2);
+        pagedResult.items.ToList().Should().HaveCount(2);
+    }
+
+    // ????????????? Instructor can view student forms ?????????????
+    [Fact]
+    public async Task ListStudentForms_ShouldReturn200_ForInstructorWithActiveFile()
+    {
+        await using var db = InMemDb();
+        var studentId = await SetupTestData(db, studentId: "student1", instructorId: "instructor1");
+
+        await AddSessionForm(db, 1, DateTime.Today.AddDays(-1), 18, "OK");
+
+        var userManager = GetMockedUserManager(db);
+        var controller = new SessionFormController(db, userManager);
+        AttachIdentity(controller, role: "Instructor", userId: "instructor1");
+
+        var result = await controller.ListStudentForms(studentId);
+
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.StatusCode.Should().Be(200);
+    }
+
+    // ????????????? Instructor forbidden for other students ?????????????
+    [Fact]
+    public async Task ListStudentForms_ShouldReturn403_ForInstructorWithoutFile()
+    {
+        await using var db = InMemDb();
+        var studentId = await SetupTestData(db, studentId: "student1", instructorId: "instructor1");
+
+        // Add instructor2 who has no file with student1
+        var instructor2 = new ApplicationUser { Id = "instructor2", UserName = "instructor2@test.com", AutoSchoolId = 1 };
+        db.Users.Add(instructor2);
+        await db.SaveChangesAsync();
+
+        var userManager = GetMockedUserManager(db);
+        var controller = new SessionFormController(db, userManager);
+        AttachIdentity(controller, role: "Instructor", userId: "instructor2"); // Different instructor
+
+        var result = await controller.ListStudentForms(studentId);
+
+        result.Result.Should().BeOfType<ForbidResult>();
+    }
+
+    // ????????????? SchoolAdmin can view school students ?????????????
+    [Fact]
+    public async Task ListStudentForms_ShouldReturn200_ForSchoolAdminSameSchool()
+    {
+        await using var db = InMemDb();
+        var studentId = await SetupTestData(db);
+
+        var admin = new ApplicationUser { Id = "admin1", UserName = "admin@test.com", AutoSchoolId = 1 };
+        db.Users.Add(admin);
+        await db.SaveChangesAsync();
+
+        await AddSessionForm(db, 1, DateTime.Today.AddDays(-1), 18, "OK");
+
+        var userManager = GetMockedUserManager(db);
+        var controller = new SessionFormController(db, userManager);
+        AttachIdentity(controller, role: "SchoolAdmin", userId: "admin1");
+
+        var result = await controller.ListStudentForms(studentId);
+
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.StatusCode.Should().Be(200);
+    }
+
+    // ????????????? SchoolAdmin forbidden for different school ?????????????
+    [Fact]
+    public async Task ListStudentForms_ShouldReturn403_ForSchoolAdminDifferentSchool()
+    {
+        await using var db = InMemDb();
+        var studentId = await SetupTestData(db);
+
+        var admin = new ApplicationUser { Id = "admin1", UserName = "admin@test.com", AutoSchoolId = 2 }; // Different school
+        db.Users.Add(admin);
+        await db.SaveChangesAsync();
+
+        var userManager = GetMockedUserManager(db);
+        var controller = new SessionFormController(db, userManager);
+        AttachIdentity(controller, role: "SchoolAdmin", userId: "admin1");
+
+        var result = await controller.ListStudentForms(studentId);
+
+        result.Result.Should().BeOfType<ForbidResult>();
+    }
+
+    // ????????????? Student forbidden to view other students ?????????????
+    [Fact]
+    public async Task ListStudentForms_ShouldReturn403_ForDifferentStudent()
+    {
+        await using var db = InMemDb();
+        var studentId = await SetupTestData(db, studentId: "student1");
+
+        var student2 = new ApplicationUser { Id = "student2", UserName = "student2@test.com", AutoSchoolId = 1 };
+        db.Users.Add(student2);
+        await db.SaveChangesAsync();
+
+        var userManager = GetMockedUserManager(db);
+        var controller = new SessionFormController(db, userManager);
+        AttachIdentity(controller, role: "Student", userId: "student2");
+
+        var result = await controller.ListStudentForms(studentId);
+
+        result.Result.Should().BeOfType<ForbidResult>();
+    }
+
+    // ????????????? Student not found ?????????????
+    [Fact]
+    public async Task ListStudentForms_ShouldReturn404_WhenStudentNotFound()
+    {
+        await using var db = InMemDb();
+
+        var admin = new ApplicationUser { Id = "admin1", UserName = "admin@test.com", AutoSchoolId = 1 };
+        db.Users.Add(admin);
+        await db.SaveChangesAsync();
+
+        var userManager = GetMockedUserManager(db);
+        var controller = new SessionFormController(db, userManager);
+        AttachIdentity(controller, role: "SchoolAdmin", userId: "admin1");
+
+        var result = await controller.ListStudentForms("nonexistent");
+
+        var notFoundResult = result.Result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.StatusCode.Should().Be(404);
+    }
+
+    // ????????????? Invalid pagination parameters ?????????????
+    [Fact]
+    public async Task ListStudentForms_ShouldReturn400_WhenPageIsZero()
+    {
+        await using var db = InMemDb();
+        var studentId = await SetupTestData(db);
+
+        var userManager = GetMockedUserManager(db);
+        var controller = new SessionFormController(db, userManager);
+        AttachIdentity(controller, role: "Student", userId: studentId);
+
+        var result = await controller.ListStudentForms(studentId, page: 0);
+
+        var badResult = result.Result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        badResult.StatusCode.Should().Be(400);
+    }
+
+    [Fact]
+    public async Task ListStudentForms_ShouldReturn400_WhenPageSizeExceedsMax()
+    {
+        await using var db = InMemDb();
+        var studentId = await SetupTestData(db);
+
+        var userManager = GetMockedUserManager(db);
+        var controller = new SessionFormController(db, userManager);
+        AttachIdentity(controller, role: "Student", userId: studentId);
+
+        var result = await controller.ListStudentForms(studentId, pageSize: 101);
+
+        var badResult = result.Result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        badResult.StatusCode.Should().Be(400);
+    }
+
+    // ????????????? Empty result ?????????????
+    [Fact]
+    public async Task ListStudentForms_ShouldReturnEmptyList_WhenNoFormsExist()
+    {
+        await using var db = InMemDb();
+        var studentId = await SetupTestData(db);
+
+        var userManager = GetMockedUserManager(db);
+        var controller = new SessionFormController(db, userManager);
+        AttachIdentity(controller, role: "Student", userId: studentId);
+
+        var result = await controller.ListStudentForms(studentId);
+
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var pagedResult = okResult.Value.Should().BeOfType<PagedResult<SessionFormListItemDto>>().Subject;
+
+        pagedResult.total.Should().Be(0);
+        pagedResult.items.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Introduces endpoints to retrieve a detailed session form view and to list a student's session forms with filtering, sorting, and pagination. Adds supporting DTOs for paged results and mistake breakdowns. Includes comprehensive integration and unit tests for new endpoints and access control.