### PR TITLE
feat(ai): add AI chat streaming proxy endpoint

### DIFF
--- a/DriveFlow-CRM-API/Controllers/AiController.cs
+++ b/DriveFlow-CRM-API/Controllers/AiController.cs
@@ -3,127 +3,177 @@ using DriveFlow_CRM_API.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
+using System.Text.Json;
 
 namespace DriveFlow_CRM_API.Controllers;
 
 /// <summary>
-/// AI context endpoints for the DriveFlow CRM API.
-/// Provides structured context data for frontend AI chatbot integration.
+/// AI chat endpoints for the DriveFlow CRM API.
+/// Provides a secure proxy to OpenRouter API with student context injection.
 /// </summary>
 /// <remarks>
-/// This controller does NOT call any AI/LLM services.
-/// It only builds context data that the frontend will use with its own LLM calls.
+/// This controller:
+/// - Builds student context server-side from the database
+/// - Calls OpenRouter API with the context and user messages
+/// - Streams responses back via Server-Sent Events (SSE)
+/// - Keeps the API key secure on the backend (never exposed to frontend)
 /// </remarks>
 [ApiController]
 [Route("api/ai")]
 public class AiController : ControllerBase
 {
     private readonly IAiContextBuilder _contextBuilder;
+    private readonly IAiStreamingService _streamingService;
 
     /// <summary>
     /// Constructor injected by the framework with request-scoped services.
     /// </summary>
-    public AiController(IAiContextBuilder contextBuilder)
+    public AiController(
+        IAiContextBuilder contextBuilder,
+        IAiStreamingService streamingService)
     {
         _contextBuilder = contextBuilder;
+        _streamingService = streamingService;
     }
 
     /// <summary>
-    /// Builds and returns the AI chatbot context for the authenticated student.
+    /// Streams AI chat responses for the authenticated student via Server-Sent Events (SSE).
     /// </summary>
     /// <remarks>
-    /// Returns a system prompt and structured context object for use with an LLM.
-    /// The frontend is responsible for calling the actual AI service.
+    /// This endpoint:
+    /// 1. Builds student context from the database (progress, mistakes, coaching notes)
+    /// 2. Prepends context as system messages to the conversation
+    /// 3. Calls OpenRouter API with streaming enabled
+    /// 4. Streams the response back to the client via SSE
     /// 
     /// <para><strong>Authorization:</strong></para>
-    /// - Only students can access their own context
-    /// - Instructors and admins are NOT allowed (use other endpoints for instructor insights)
+    /// - Only students can access this endpoint
+    /// - Student context is built server-side using the authenticated user's ID
     /// 
     /// <para><strong>Request body:</strong></para>
     /// <code>
     /// {
-    ///   "historySessions": 5,    // Number of recent sessions to include per category (1-50)
-    ///   "language": "ro"         // Language for system prompt ("ro" or "en")
+    ///   "messages": [
+    ///     { "role": "user", "content": "Cum mă pot pregăti mai bine?" },
+    ///     { "role": "assistant", "content": "Bună! Văd că ai..." },
+    ///     { "role": "user", "content": "Ce greșeli fac cel mai des?" }
+    ///   ],
+    ///   "historySessions": 5,    // Optional, default 5 (sessions per category for context)
+    ///   "language": "ro"         // Optional, default "ro" (system prompt language)
     /// }
     /// </code>
     /// 
-    /// <para><strong>Response format:</strong></para>
+    /// <para><strong>SSE Response format:</strong></para>
     /// <code>
-    /// {
-    ///   "generatedAt": "2026-01-27T10:30:00Z",
-    ///   "systemPrompt": "Ești un asistent virtual...",
-    ///   "context": {
-    ///     "student": { "fullName": "Ion Popescu", ... },
-    ///     "categories": [ { "categoryCode": "B", ... } ],
-    ///     "overallProgress": { ... },
-    ///     "commonMistakes": [ { "description": "...", ... } ],
-    ///     "strongSkills": [ "..." ],
-    ///     "skillsNeedingImprovement": [ "..." ],
-    ///     "latestSessionHighlights": [ { ... } ],
-    ///     "coachingNotes": [ "..." ],
-    ///     "dataAvailability": { ... }
-    ///   }
-    /// }
+    /// event: chunk
+    /// data: Bună
+    /// 
+    /// event: chunk
+    /// data: , Ion!
+    /// 
+    /// event: chunk
+    /// data:  Văd că ai
+    /// 
+    /// event: done
+    /// data:
     /// </code>
     /// 
-    /// <para><strong>Edge cases handled:</strong></para>
-    /// - Student with zero sessions: Returns empty arrays with appropriate warnings
-    /// - Student with multiple categories: Each category has separate progress tracking
-    /// - Missing evaluation data: Clearly indicated in dataAvailability section
+    /// <para><strong>Error event:</strong></para>
+    /// <code>
+    /// event: error
+    /// data: {"message": "Failed to connect to AI service"}
+    /// </code>
+    /// 
+    /// <para><strong>Conversation flow:</strong></para>
+    /// - Frontend sends full conversation history with each request
+    /// - Backend prepends fresh context (from database) on every request
+    /// - Context is always up-to-date with student's latest progress
     /// </remarks>
-    /// <param name="request">Optional parameters for context building</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    /// <response code="200">Context built successfully</response>
+    /// <param name="request">Chat request with conversation messages</param>
+    /// <response code="200">SSE stream started successfully</response>
     /// <response code="401">User is not authenticated</response>
-    /// <response code="403">User is not a student or trying to access another user's context</response>
-    /// <response code="404">Student not found</response>
-    [HttpPost("context/student")]
+    /// <response code="403">User is not a student</response>
+    /// <response code="404">Student not found in database</response>
+    [HttpPost("chat/stream")]
     [Authorize(Roles = "Student")]
-    [ProducesResponseType(typeof(AiStudentContextResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<AiStudentContextResponse>> GetStudentContext(
-        [FromBody] AiStudentContextRequest? request = null,
-        CancellationToken cancellationToken = default)
+    public async Task StreamChat([FromBody] ChatRequest request)
     {
-        // 1. Get authenticated user's ID
+        // 1. Get authenticated user's ID from JWT claims
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (string.IsNullOrEmpty(userId))
         {
-            return Unauthorized(new { message = "User not authenticated" });
+            Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await Response.WriteAsJsonAsync(new { message = "User not authenticated" });
+            return;
         }
 
         // 2. Verify the user has Student role (additional check beyond [Authorize])
         if (!User.IsInRole("Student"))
         {
-            return Forbid();
+            Response.StatusCode = StatusCodes.Status403Forbidden;
+            await Response.WriteAsJsonAsync(new { message = "Access denied" });
+            return;
         }
 
-        // 3. Use defaults if request is null
-        var historySessions = request?.HistorySessions ?? 5;
-        var language = request?.Language ?? "ro";
+        // 3. Build student context from database
+        var historySessions = request.HistorySessions ?? 5;
+        var language = request.Language ?? "ro";
 
-        // 4. Build the context
         var context = await _contextBuilder.BuildStudentContextAsync(
             userId,
             historySessions,
             language,
-            cancellationToken);
+            HttpContext.RequestAborted);
 
         if (context == null)
         {
-            return NotFound(new { message = "Student not found" });
+            Response.StatusCode = StatusCodes.Status404NotFound;
+            await Response.WriteAsJsonAsync(new { message = "Student not found" });
+            return;
         }
 
-        return Ok(context);
+        // 4. Prepare messages for OpenRouter
+        //    - Message 1 (system): The system prompt with AI behavior instructions
+        //    - Message 2 (system): The student context as JSON
+        //    - Messages 3+: The conversation history from the request
+        var messages = new List<object>
+        {
+            new { role = "system", content = context.SystemPrompt },
+            new { role = "system", content = JsonSerializer.Serialize(context.Context) }
+        };
+
+        // Add conversation history from request
+        if (request.Messages != null)
+        {
+            messages.AddRange(request.Messages.Select(m => new
+            {
+                role = m.Role,
+                content = m.Content
+            }));
+        }
+
+        // 5. Set SSE headers
+        Response.ContentType = "text/event-stream";
+        Response.Headers.Append("Cache-Control", "no-cache");
+        Response.Headers.Append("Connection", "keep-alive");
+        Response.Headers.Append("X-Accel-Buffering", "no"); // Disable nginx buffering
+
+        // 6. Stream response from OpenRouter to client
+        await _streamingService.StreamToClientAsync(
+            messages,
+            Response,
+            HttpContext.RequestAborted);
     }
 
     /// <summary>
-    /// Health check endpoint for the AI context service.
+    /// Health check endpoint for the AI chat service.
     /// </summary>
     /// <remarks>
-    /// Simple endpoint to verify the AI context service is available.
+    /// Simple endpoint to verify the AI chat service is available.
     /// Does not require authentication.
     /// </remarks>
     /// <response code="200">Service is healthy</response>
@@ -132,12 +182,17 @@ public class AiController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     public ActionResult<object> HealthCheck()
     {
+        // Check if OpenRouter is configured
+        var apiKeyConfigured = !string.IsNullOrEmpty(
+            Environment.GetEnvironmentVariable("OPENROUTER_API_KEY"));
+
         return Ok(new
         {
             status = "healthy",
-            service = "ai-context",
+            service = "ai-chat",
             timestamp = DateTime.UtcNow,
-            version = "1.0.0"
+            version = "2.0.0",
+            openRouterConfigured = apiKeyConfigured
         });
     }
 }

--- a/DriveFlow-CRM-API/Json/AppJsonContext.cs
+++ b/DriveFlow-CRM-API/Json/AppJsonContext.cs
@@ -131,8 +131,10 @@ namespace DriveFlow_CRM_API.Json
     [JsonSerializable(typeof(CreateInstructorAvailabilityDto))]
 
     // ───────────────────────── AI CONTROLLER ─────────────────────────
-    [JsonSerializable(typeof(AiStudentContextRequest))]
-    [JsonSerializable(typeof(AiStudentContextResponse))]
+    [JsonSerializable(typeof(ChatRequest))]
+    [JsonSerializable(typeof(ChatMessage))]
+    [JsonSerializable(typeof(List<ChatMessage>))]
+    [JsonSerializable(typeof(AiStudentContextResponse))]  // Used internally by AiContextBuilder
     [JsonSerializable(typeof(StudentContextDto))]
     [JsonSerializable(typeof(StudentSummaryDto))]
     [JsonSerializable(typeof(CategoryProgressDto))]

--- a/DriveFlow-CRM-API/Models/DTOs/AiContextDtos.cs
+++ b/DriveFlow-CRM-API/Models/DTOs/AiContextDtos.cs
@@ -4,17 +4,48 @@ namespace DriveFlow_CRM_API.Models.DTOs;
 //  AI CONTEXT DTOs - Request/Response for the AI chatbot context endpoint
 // ═══════════════════════════════════════════════════════════════════════════════
 
-#region Request/Response DTOs
+#region Chat Request/Response DTOs
 
 /// <summary>
-/// Request DTO for building AI student context.
+/// Request DTO for the AI chat streaming endpoint.
 /// </summary>
-/// <param name="HistorySessions">Number of recent sessions to include per file (default: 5)</param>
-/// <param name="Language">Language code for the system prompt (default: "ro")</param>
-public sealed record AiStudentContextRequest(
-    int HistorySessions = 5,
-    string? Language = "ro"
-);
+public sealed class ChatRequest
+{
+    /// <summary>
+    /// Conversation messages (user and assistant history).
+    /// </summary>
+    public List<ChatMessage> Messages { get; set; } = new();
+
+    /// <summary>
+    /// Number of recent sessions to include per category for context (default: 5).
+    /// </summary>
+    public int? HistorySessions { get; set; } = 5;
+
+    /// <summary>
+    /// Language code for the system prompt ("ro" or "en", default: "ro").
+    /// </summary>
+    public string? Language { get; set; } = "ro";
+}
+
+/// <summary>
+/// A single message in the chat conversation.
+/// </summary>
+public sealed class ChatMessage
+{
+    /// <summary>
+    /// Message role: "user" or "assistant".
+    /// </summary>
+    public string Role { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Message content/text.
+    /// </summary>
+    public string Content { get; set; } = string.Empty;
+}
+
+#endregion
+
+#region Internal Context DTOs
 
 /// <summary>
 /// Response DTO containing the system prompt and student context for the LLM.

--- a/DriveFlow-CRM-API/Program.cs
+++ b/DriveFlow-CRM-API/Program.cs
@@ -298,7 +298,10 @@ public partial class Program
         // 5) AI Context Builder service (builds LLM context for student chatbot)
         builder.Services.AddScoped<IAiContextBuilder, AiContextBuilder>();
 
-        // 6) HttpClient factory for external service communications
+        // 6) AI Streaming Service (proxies requests to OpenRouter API)
+        builder.Services.AddScoped<IAiStreamingService, AiStreamingService>();
+
+        // 7) HttpClient factory for external service communications (used by AI streaming)
         builder.Services.AddHttpClient();
 
         // ─────────────────────────────── Rate-Limit / Cool-down ──────────────────────────────

--- a/DriveFlow-CRM-API/Services/AiStreamingService.cs
+++ b/DriveFlow-CRM-API/Services/AiStreamingService.cs
@@ -1,0 +1,213 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace DriveFlow_CRM_API.Services;
+
+/// <summary>
+/// Implements AI chat streaming via OpenRouter API with Server-Sent Events (SSE).
+/// Reads configuration from environment variables and streams responses to clients.
+/// </summary>
+public sealed class AiStreamingService : IAiStreamingService
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<AiStreamingService> _logger;
+
+    // Environment variable keys
+    private const string ApiKeyEnvVar = "OPENROUTER_API_KEY";
+    private const string ModelEnvVar = "OPENROUTER_MODEL";
+    private const string BaseUrlEnvVar = "OPENROUTER_BASE_URL";
+
+    // Default values
+    private const string DefaultModel = "deepseek/deepseek-r1-0528:free";
+    private const string DefaultBaseUrl = "https://openrouter.ai/api/v1";
+
+    public AiStreamingService(
+        IHttpClientFactory httpClientFactory,
+        ILogger<AiStreamingService> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task StreamToClientAsync(
+        List<object> messages,
+        HttpResponse response,
+        CancellationToken cancellationToken)
+    {
+        // Read configuration from environment
+        var apiKey = Environment.GetEnvironmentVariable(ApiKeyEnvVar);
+        var model = Environment.GetEnvironmentVariable(ModelEnvVar) ?? DefaultModel;
+        var baseUrl = Environment.GetEnvironmentVariable(BaseUrlEnvVar) ?? DefaultBaseUrl;
+
+        // Validate API key
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            _logger.LogError("OpenRouter API key not configured. Set {EnvVar} environment variable.", ApiKeyEnvVar);
+            await WriteErrorEventAsync(response, "AI service not configured", cancellationToken);
+            return;
+        }
+
+        // Clean up model and baseUrl (remove quotes if present from env file)
+        model = model.Trim('"');
+        baseUrl = baseUrl.Trim('"');
+
+        // Build the endpoint URL
+        var endpoint = $"{baseUrl.TrimEnd('/')}/chat/completions";
+
+        try
+        {
+            // Create HTTP client
+            var client = _httpClientFactory.CreateClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey.Trim('"'));
+            client.DefaultRequestHeaders.Add("HTTP-Referer", "https://driveflow.ro");
+            client.DefaultRequestHeaders.Add("X-Title", "DriveFlow CRM");
+
+            // Build request payload
+            var requestBody = new
+            {
+                model = model,
+                stream = true,
+                messages = messages
+            };
+
+            var jsonContent = JsonSerializer.Serialize(requestBody);
+            var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
+
+            // Make streaming request
+            using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+            {
+                Content = content
+            };
+
+            using var httpResponse = await client.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken);
+
+            if (!httpResponse.IsSuccessStatusCode)
+            {
+                var errorBody = await httpResponse.Content.ReadAsStringAsync(cancellationToken);
+                _logger.LogError("OpenRouter API error: {StatusCode} - {Body}", httpResponse.StatusCode, errorBody);
+                await WriteErrorEventAsync(response, $"AI service error: {httpResponse.StatusCode}", cancellationToken);
+                return;
+            }
+
+            // Stream the response
+            using var stream = await httpResponse.Content.ReadAsStreamAsync(cancellationToken);
+            using var reader = new StreamReader(stream);
+
+            while (!reader.EndOfStream && !cancellationToken.IsCancellationRequested)
+            {
+                var line = await reader.ReadLineAsync(cancellationToken);
+
+                if (string.IsNullOrEmpty(line))
+                    continue;
+
+                // OpenRouter sends lines prefixed with "data: "
+                if (!line.StartsWith("data: "))
+                    continue;
+
+                var data = line.Substring(6); // Remove "data: " prefix
+
+                // Check for stream end
+                if (data == "[DONE]")
+                {
+                    await WriteDoneEventAsync(response, cancellationToken);
+                    break;
+                }
+
+                // Parse the JSON chunk
+                try
+                {
+                    using var doc = JsonDocument.Parse(data);
+                    var root = doc.RootElement;
+
+                    // Extract content from choices[0].delta.content
+                    if (root.TryGetProperty("choices", out var choices) &&
+                        choices.GetArrayLength() > 0)
+                    {
+                        var firstChoice = choices[0];
+                        if (firstChoice.TryGetProperty("delta", out var delta) &&
+                            delta.TryGetProperty("content", out var contentElement))
+                        {
+                            var text = contentElement.GetString();
+                            if (!string.IsNullOrEmpty(text))
+                            {
+                                await WriteChunkEventAsync(response, text, cancellationToken);
+                            }
+                        }
+                    }
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse SSE chunk: {Data}", data);
+                    // Continue processing other chunks
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogDebug("Client disconnected, streaming cancelled");
+            // Client disconnected - this is normal
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Failed to connect to OpenRouter API");
+            await WriteErrorEventAsync(response, "Failed to connect to AI service", cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error during AI streaming");
+            await WriteErrorEventAsync(response, "An unexpected error occurred", cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Writes a chunk SSE event to the response.
+    /// </summary>
+    private static async Task WriteChunkEventAsync(
+        HttpResponse response,
+        string text,
+        CancellationToken cancellationToken)
+    {
+        var eventData = $"event: chunk\ndata: {EscapeSseData(text)}\n\n";
+        await response.WriteAsync(eventData, cancellationToken);
+        await response.Body.FlushAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Writes a done SSE event to the response.
+    /// </summary>
+    private static async Task WriteDoneEventAsync(
+        HttpResponse response,
+        CancellationToken cancellationToken)
+    {
+        await response.WriteAsync("event: done\ndata:\n\n", cancellationToken);
+        await response.Body.FlushAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Writes an error SSE event to the response.
+    /// </summary>
+    private static async Task WriteErrorEventAsync(
+        HttpResponse response,
+        string message,
+        CancellationToken cancellationToken)
+    {
+        var errorJson = JsonSerializer.Serialize(new { message });
+        await response.WriteAsync($"event: error\ndata: {errorJson}\n\n", cancellationToken);
+        await response.Body.FlushAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Escapes newlines in SSE data (each line needs a "data: " prefix).
+    /// </summary>
+    private static string EscapeSseData(string text)
+    {
+        // SSE spec: multiline data needs each line prefixed with "data: "
+        // For simplicity, we'll escape newlines as they're rare in chat chunks
+        return text.Replace("\n", "\\n").Replace("\r", "\\r");
+    }
+}

--- a/DriveFlow-CRM-API/Services/IAiStreamingService.cs
+++ b/DriveFlow-CRM-API/Services/IAiStreamingService.cs
@@ -1,0 +1,24 @@
+namespace DriveFlow_CRM_API.Services;
+
+/// <summary>
+/// Service interface for streaming AI chat responses via Server-Sent Events (SSE).
+/// Handles communication with the OpenRouter API and streams responses back to clients.
+/// </summary>
+public interface IAiStreamingService
+{
+    /// <summary>
+    /// Streams AI chat responses to the client via SSE.
+    /// </summary>
+    /// <param name="messages">
+    /// List of messages to send to OpenRouter. Should include:
+    /// - System message(s) with prompt and context
+    /// - User/assistant conversation history
+    /// </param>
+    /// <param name="response">The HTTP response to stream SSE events to.</param>
+    /// <param name="cancellationToken">Cancellation token for client disconnect handling.</param>
+    /// <returns>Task that completes when streaming is finished or cancelled.</returns>
+    Task StreamToClientAsync(
+        List<object> messages,
+        HttpResponse response,
+        CancellationToken cancellationToken);
+}

--- a/sample.env
+++ b/sample.env
@@ -2,3 +2,7 @@ DB_CONNECTION_URI=mysql://root:DBName@192.168.0.1:9999/Smth
 ASPNETCORE_ENVIRONMENT=Production
 JWT_KEY=THE_Best_JWT_Token_823844#8^4156$32#@521
 INVOICE_SERVICE_URL=http://172.17.0.1:5001/api/v1/getInvoice
+
+OPENROUTER_MODEL="deepseek/deepseek-r1-0528:free"
+OPENROUTER_API_KEY="sk-XXXXXXXXXX" 
+OPENROUTER_BASE_URL="https://openrouter.ai/api/v1"


### PR DESCRIPTION
- Add POST /api/ai/chat/stream endpoint for SSE streaming
- Create AiStreamingService to proxy requests to OpenRouter API
- Build student context server-side (keeps API key secure)
- Remove old /api/ai/context/student endpoint (no longer needed)
- Add ChatRequest and ChatMessage DTOs
- Register services in DI container
- Add OpenRouter env vars to sample.env

The frontend now communicates through this proxy endpoint, sending conversation history. The backend prepends fresh student context on every request and streams AI responses back via Server-Sent Events.

Security: OpenRouter API key never exposed to frontend